### PR TITLE
Add FastAPI server and stub evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# llm_ut
+# Prompt Tuning Evaluation Prototype
+
+This project is a minimal implementation of the platform described in `task_description.md`.
+It exposes a small FastAPI service that lets you submit Jinja prompt templates and view
+aggregated evaluation results.
+
+## Running
+
+1. Install dependencies (FastAPI, SQLModel, Jinja2, etc.):
+   ```bash
+   bash install_dependencies
+   ```
+   *Note: packages require internet access.*
+2. Start the server:
+   ```bash
+   uvicorn main:app
+   ```
+3. Open `http://localhost:8000/` in a browser to use the dashboard.
+
+The evaluation pipeline in `pipeline.py` is intentionally simple and does not call
+any external LLMs. It renders the template against each case in `basket.json`,
+performs a trivial evaluation, stores results in SQLite and updates metrics for
+the prompt version.

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,15 +1,66 @@
-# pipeline.py
-
-import json, asyncio
+import json
 from jinja2 import Template
-import openai
-from .models import PromptVersion, ResponseRecord
+from typing import Dict, List
+from sqlmodel import select
+from app.model import PromptVersion, ResponseRecord
+from app.database import get_session, AsyncSession
 
-# load basket once
 with open("basket.json") as f:
     BASKET = json.load(f)
 
-# 1. generate_answers(prompt_text) → {case_id: answer_text}
-# 2. evaluate_answers(answers) → {case_id: raw_eval_text}
-# 3. parse_flags(raw_eval) → flags dict + final_flag
-# 4. aggregate_metrics(all_flags) → metrics_summary
+def simple_evaluate(answer: str) -> str:
+    correctness = "Yes" if "return" in answer else "No"
+    code_presence = "Yes" if "def" in answer else "No"
+    line_reference = "Yes" if "line" in answer else "No"
+    return (
+        f"<correctness>{correctness}</correctness>"
+        f"<code_presence>{code_presence}</code_presence>"
+        f"<line_reference>{line_reference}</line_reference>"
+    )
+
+def parse_flags(raw: str) -> Dict[str, bool]:
+    def extract(tag: str) -> bool:
+        open_t = f"<{tag}>"
+        close_t = f"</{tag}>"
+        if open_t in raw and close_t in raw:
+            val = raw.split(open_t)[1].split(close_t)[0].strip()
+            return val.lower() == "yes"
+        return False
+    return {
+        "correctness": extract("correctness"),
+        "code_presence": extract("code_presence"),
+        "line_reference": extract("line_reference"),
+    }
+
+async def process_prompt(prompt_id: str, text: str):
+    template = Template(text)
+    async with get_session() as session:
+        responses: List[ResponseRecord] = []
+        for case in BASKET:
+            answer = template.render(**case)
+            raw_eval = simple_evaluate(answer)
+            flags = parse_flags(raw_eval)
+            final_flag = all(flags.values())
+            rec = ResponseRecord(
+                prompt_id=prompt_id,
+                case_id=case["id"],
+                answer=answer,
+                raw_evaluation=raw_eval,
+                flags=flags,
+                final_flag=final_flag,
+            )
+            session.add(rec)
+            responses.append(rec)
+        await session.commit()
+        if responses:
+            metrics = {
+                "correctness": sum(r.flags["correctness"] for r in responses) / len(responses),
+                "code_presence": sum(r.flags["code_presence"] for r in responses) / len(responses),
+                "line_reference": sum(r.flags["line_reference"] for r in responses) / len(responses),
+            }
+            metrics["final_score"] = sum(r.final_flag for r in responses) / len(responses)
+            result = await session.exec(select(PromptVersion).where(PromptVersion.prompt_id == prompt_id))
+            pv = result.one()
+            pv.metrics = metrics
+            session.add(pv)
+            await session.commit()


### PR DESCRIPTION
## Summary
- implement FastAPI app exposing prompt endpoints
- implement simple evaluation pipeline and metrics
- update README with instructions for running the prototype

## Testing
- `python -m py_compile app/*.py main.py pipeline.py`
- `bash install_dependencies` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684599bba93883219005e5a59e022c3a