### PR TITLE
Resolve conflict in pipeline with LLM validation code

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1,9 +1,39 @@
 import json
+import asyncio
+import requests
 from jinja2 import Template
 from typing import Dict, List
 from sqlmodel import select
 from app.model import PromptVersion, ResponseRecord
 from app.database import get_session, AsyncSession
+
+# LLM configuration
+with open("oauth.txt", "r", encoding="utf-8") as f:
+    _TOKEN = f.readline().strip()
+
+_MODEL_URL = (
+    "http://zeliboba.yandex-team.ru/balance/qwen3_23B_edu_ml/v1/chat/completions"
+)
+
+_HEADERS = {
+    "Content-Type": "application/json",
+    "X-Model-Discovery-Oauth-Token": _TOKEN,
+    "Authorization": "Bearer EMPTY",
+}
+
+
+def call_validation_llm(messages, max_tokens: int = 32000, temperature: int = 0) -> str:
+    """Send messages to the validation LLM and return the text response."""
+    payload = {
+        "model": "does_not_matter",
+        "messages": messages,
+        "stream": False,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    resp = requests.post(_MODEL_URL, headers=_HEADERS, json=payload)
+    resp.raise_for_status()
+    return resp.json()["choices"][0]["message"]["content"]
 
 with open("basket.json") as f:
     BASKET = json.load(f)


### PR DESCRIPTION
## Summary
- restore missing imports and configuration for LLM-based validation
- provide `call_validation_llm` helper used for validating answers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b8d4cdc88321917ad73d220bf5db