### PR TITLE
Fix uvicorn startup error due to dict fields

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -1,12 +1,15 @@
 from typing import Optional, Dict
 from datetime import datetime
 from sqlmodel import SQLModel, Field
+from sqlalchemy import Column, JSON
 
 class PromptVersion(SQLModel, table=True):
     prompt_id: str = Field(default=None, primary_key=True)
     prompt_text: str
     created_at: datetime = Field(default_factory=datetime.utcnow)
-    metrics: Dict[str, float]  # e.g. correctness, code_presence, line_reference, final_score
+    metrics: Dict[str, float] = Field(
+        default_factory=dict, sa_column=Column(JSON)
+    )  # e.g. correctness, code_presence, line_reference, final_score
 
 class ResponseRecord(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -14,5 +17,5 @@ class ResponseRecord(SQLModel, table=True):
     case_id: int
     answer: str
     raw_evaluation: str
-    flags: Dict[str, bool]
+    flags: Dict[str, bool] = Field(default_factory=dict, sa_column=Column(JSON))
     final_flag: bool


### PR DESCRIPTION
## Summary
- store metrics and flags as JSON columns

## Testing
- `python -m py_compile main.py app/model.py pipeline.py app/database.py`

------
https://chatgpt.com/codex/tasks/task_e_6845cebaeabc8321b880f647bf71a2b8