### PR TITLE
Add logging of rendered prompts

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -70,6 +70,8 @@ async def process_prompt(prompt_id: str, text: str):
         responses: List[ResponseRecord] = []
         for case in BASKET:
             answer = template.render(**case)
+            # Log the rendered prompt for debugging/inspection
+            print(f"[prompt:{prompt_id} case:{case['id']}] {answer}")
             raw_eval = simple_evaluate(answer)
             flags = parse_flags(raw_eval)
             final_flag = all(flags.values())


### PR DESCRIPTION
## Summary
- print rendered template strings when processing new prompts

## Testing
- `python -m py_compile pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68465be5e20083219220ca01d833a0f9