### PR TITLE
Update generation LLM payload handling

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -53,16 +53,19 @@ _HEADERS = {
 def call_generation_llm(messages, max_tokens: int = 32000, temperature: int = 0) -> str:
     """Send messages to the answer LLM and return the text response."""
     payload = {
-        "model": "does_not_matter",
+        "Params": {"NumHypos": 1, "Seed": 42},
         "messages": messages,
-        "stream": False,
         "max_tokens": max_tokens,
         "temperature": temperature,
     }
     print(f"[LLM Request] url={_ANSWER_URL} payload={json.dumps(payload)}")
     resp = requests.post(_ANSWER_URL, headers=_HEADERS, json=payload)
     resp.raise_for_status()
-    return resp.json()["choices"][0]["message"]["content"]
+    data = resp.json()
+    chunk = data["Responses"][0]
+    if not chunk.get("ReachedEos"):
+        raise RuntimeError("generation did not finish with eos")
+    return chunk["Response"]
 
 
 def call_validation_llm(messages, max_tokens: int = 32000, temperature: int = 0) -> str:


### PR DESCRIPTION
## Summary
- update `call_generation_llm` to send Params payload and check `ReachedEos`
- add tests covering payload structure and EOS verification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466f5efda883218935be6de78b2e91