### PR TITLE
Update answer LLM request format

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -46,17 +46,16 @@ _EVAL_URL = (
 _HEADERS = {
     "Content-Type": "application/json",
     "X-Model-Discovery-Oauth-Token": _TOKEN,
-    "Authorization": "Bearer EMPTY",
 }
 
 
-def call_generation_llm(messages, max_tokens: int = 32000, temperature: int = 0) -> str:
+def call_generation_llm(messages, params=None) -> str:
     """Send messages to the answer LLM and return the text response."""
+    if params is None:
+        params = {"NumHypos": 1, "Seed": 42}
     payload = {
-        "Params": {"NumHypos": 1, "Seed": 42},
         "messages": messages,
-        "max_tokens": max_tokens,
-        "temperature": temperature,
+        "Params": params,
     }
     print(f"[LLM Request] url={_ANSWER_URL} payload={json.dumps(payload)}")
     resp = requests.post(_ANSWER_URL, headers=_HEADERS, json=payload)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -42,18 +42,17 @@ def test_call_generation_llm_parses_response(monkeypatch):
 
     monkeypatch.setattr(pipeline.requests, "post", fake_post)
 
+    params = {"NumHypos": 1, "Seed": 42}
     result = pipeline.call_generation_llm(
-        [{"role": "user", "content": "hi"}], max_tokens=5, temperature=1
+        [{"role": "user", "content": "hi"}], params=params
     )
 
     assert result == "hello"
     assert captured['url'] == pipeline._ANSWER_URL
     assert captured['headers'] == pipeline._HEADERS
     assert captured['json'] == {
-        "Params": {"NumHypos": 1, "Seed": 42},
+        "Params": params,
         "messages": [{"role": "user", "content": "hi"}],
-        "max_tokens": 5,
-        "temperature": 1,
     }
 
 


### PR DESCRIPTION
## Summary
- remove unused `Authorization` header and send params as in the TS client
- adjust `call_generation_llm` to accept `params` and build payload accordingly
- update unit test to reflect new request format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684671b766088321aea02916414d25c3