### PR TITLE
Use single LLM endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ aggregated evaluation results.
    ```
 3. Open `http://localhost:8000/` in a browser to use the dashboard.
 
+By default both generation and evaluation requests are sent to the same LLM
+endpoint. Set the environment variable `USE_SINGLE_LLM_ENDPOINT=false` to
+restore the previous behaviour with separate endpoints.
+
 To verify the code, run the test suite with:
 ```bash
 pytest -q

--- a/pipeline.py
+++ b/pipeline.py
@@ -39,9 +39,15 @@ if not _TOKEN:
 _ANSWER_URL = (
     "http://zeliboba.yandex-team.ru/balance/32b_aligned_quantized_202502/generative"
 )
-_EVAL_URL = (
+_EVAL_URL_DEFAULT = (
     "http://zeliboba.yandex-team.ru/balance/qwen3_23B_edu_ml/v1/chat/completions"
 )
+_USE_SINGLE_LLM_ENDPOINT = os.getenv("USE_SINGLE_LLM_ENDPOINT", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+_EVAL_URL = _ANSWER_URL if _USE_SINGLE_LLM_ENDPOINT else _EVAL_URL_DEFAULT
 
 _HEADERS = {
     "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- make evaluation requests use the same endpoint as generation by default
- allow switching back to separate endpoints through `USE_SINGLE_LLM_ENDPOINT` env var
- document the new environment variable in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846788284b08321b7685cfc90f3fb6c