### PR TITLE
Fix evaluation message role

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -154,7 +154,7 @@ def evaluate_answer(
     ).format(program=program, error=error, advice=advice)
 
     messages = [
-        {"role": "assessor", "content": prompt},
+        {"role": "user", "content": prompt},
     ]
     return llm_fn(messages, **llm_kwargs)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -158,3 +158,22 @@ def test_call_validation_llm_separate_endpoint(monkeypatch):
         "max_tokens": 10,
         "temperature": 1,
     }
+
+
+def test_evaluate_answer_sends_user_message(monkeypatch):
+    import pipeline
+
+    captured = {}
+
+    def fake_llm(messages, **kwargs):
+        captured['messages'] = messages
+        return "<right_error_description>Yes</right_error_description>"
+
+    program = "print(1)"
+    error = ""
+    advice = "do nothing"
+
+    pipeline.evaluate_answer(program, error, advice, llm_fn=fake_llm)
+
+    assert captured['messages'][0]['role'] == 'user'
+    assert program in captured['messages'][0]['content']


### PR DESCRIPTION
## Summary
- send evaluation prompt using valid `user` role
- add test for evaluate_answer role

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846801c13fc83218d49bf457e24e024