### PR TITLE
Fix metric field names

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,17 @@ async def root():
 async def add_prompt(payload: dict, background: BackgroundTasks, session: AsyncSession = Depends(get_session)):
     text = payload.get("prompt_text", "")
     pid = str(uuid.uuid4())
-    pv = PromptVersion(prompt_id=pid, prompt_text=text, metrics={"correctness":0, "code_presence":0, "line_reference":0, "final_score":0})
+    pv = PromptVersion(
+        prompt_id=pid,
+        prompt_text=text,
+        metrics={
+            "right_error_description": 0,
+            "correct_hint": 0,
+            "correct_or_absent_code": 0,
+            "correct_line_reference": 0,
+            "final_score": 0,
+        },
+    )
     session.add(pv)
     await session.commit()
     background.add_task(process_prompt, pid, text)

--- a/static/app.js
+++ b/static/app.js
@@ -28,13 +28,14 @@ async function refreshList() {
     prompts.forEach((p, i) => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td>${i+1}</td>
+        <td>${i + 1}</td>
         <td><a href="#" onclick="showDetails('${p.prompt_id}')">${p.prompt_id}</a></td>
         <td>${new Date(p.created_at).toLocaleString()}</td>
-        <td>${(p.metrics.correctness*100).toFixed(1)}%</td>
-        <td>${(p.metrics.code_presence*100).toFixed(1)}%</td>
-        <td>${(p.metrics.line_reference*100).toFixed(1)}%</td>
-        <td>${(p.metrics.final_score*100).toFixed(1)}%</td>
+        <td>${(p.metrics.right_error_description * 100).toFixed(1)}%</td>
+        <td>${(p.metrics.correct_hint * 100).toFixed(1)}%</td>
+        <td>${(p.metrics.correct_or_absent_code * 100).toFixed(1)}%</td>
+        <td>${(p.metrics.correct_line_reference * 100).toFixed(1)}%</td>
+        <td>${(p.metrics.final_score * 100).toFixed(1)}%</td>
         <td><button onclick="deletePrompt('${p.prompt_id}')">Delete</button></td>
       `;
       tbody.appendChild(tr);

--- a/static/index.html
+++ b/static/index.html
@@ -40,8 +40,9 @@
           <th>Rank</th>
           <th>Prompt ID</th>
           <th>Created At</th>
-          <th>Correctness</th>
-          <th>Code?</th>
+          <th>Right Err</th>
+          <th>Hint</th>
+          <th>No Code</th>
           <th>Line Ref</th>
           <th>Final Score</th>
           <th>Delete</th>


### PR DESCRIPTION
## Summary
- update frontend to display new metric keys
- add new metric columns in index
- initialize PromptVersion with new metric keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468d64632c83219a2f6255740a7f05