### PR TITLE
Use requirements.txt for dependencies

### DIFF
--- a/MVP_PLAN.md
+++ b/MVP_PLAN.md
@@ -4,7 +4,7 @@ This document outlines the steps required to build a minimal viable product for 
 
 ## 1. Environment Setup
 
-1. Install dependencies using `install_dependencies` script.
+1. Install dependencies with `pip install -r requirements.txt`.
 2. Prepare an `.env` file with required OpenAI credentials.
 3. Initialize the SQLite database using the utility in `app/database.py`.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ aggregated evaluation results.
 
 ## Running
 
-1. Install dependencies (FastAPI, SQLModel, Jinja2, Pytest, etc.):
+1. Install dependencies using `requirements.txt`:
    ```bash
-   bash install_dependencies
+   pip install -r requirements.txt
    ```
    *Note: packages require internet access.*
 2. Start the server:

--- a/install_dependencies
+++ b/install_dependencies
@@ -1,1 +1,0 @@
-pip install fastapi uvicorn jinja2 openai sqlmodel aiosqlite pytest pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+jinja2
+openai
+sqlmodel
+aiosqlite
+pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- replace `install_dependencies` with `requirements.txt`
- update docs to install dependencies via pip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684692ce317883218aee8f053a7b7d27