### PR TITLE
Add LLM interaction logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ The evaluation pipeline in `pipeline.py` is intentionally simple and does not ca
 any external LLMs. It renders the template against each case in `basket.json`,
 performs a trivial evaluation, stores results in SQLite and updates metrics for
 the prompt version.
+
+All raw requests and responses exchanged with the models are stored in the
+`LLMInteraction` table and can be downloaded via the `/logs` endpoint.

--- a/app/model.py
+++ b/app/model.py
@@ -19,3 +19,15 @@ class ResponseRecord(SQLModel, table=True):
     raw_evaluation: str
     flags: Dict[str, bool] = Field(default_factory=dict, sa_column=Column(JSON))
     final_flag: bool
+
+
+class LLMInteraction(SQLModel, table=True):
+    """Store raw requests and responses sent to language models."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    prompt_id: str
+    question_id: int
+    request_type: str
+    request_payload: Dict = Field(default_factory=dict, sa_column=Column(JSON))
+    response: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,7 @@
 <body>
 
   <h1>Prompt Tuning Dashboard</h1>
+  <p><a href="/logs">Download Logs (JSON)</a></p>
 
   <!-- 1. Prompt Submission Form -->
   <section id="new-prompt">


### PR DESCRIPTION
## Summary
- capture all LLM requests/responses
- store them with `prompt_id` and `question_id`
- expose new `/logs` endpoint
- update README and UI with download link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c40569d483219ba0710e4b6abef1