### PR TITLE
Add scroll constraint to modal

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,19 @@
     tr:hover { background: #fafafa; }
     .spinner { display: inline-block; width: 1rem; height: 1rem; border: 2px solid #ccc; border-top-color: #333; border-radius: 50%; animation: spin 0.6s linear infinite; }
     @keyframes spin { to { transform: rotate(360deg); } }
-    .modal { position: fixed; top: 10%; left: 50%; transform: translateX(-50%); background: white; border: 1px solid #ccc; padding: 1rem; box-shadow: 0 2px 8px rgba(0,0,0,0.2); display: none; }
+    .modal {
+      position: fixed;
+      top: 10%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: white;
+      border: 1px solid #ccc;
+      padding: 1rem;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+      display: none;
+      max-height: 80vh;
+      overflow-y: auto;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- adjust modal CSS in `static/index.html` to limit height and enable scrolling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846cdf28e40832191d5e565d18eb8d9