### PR TITLE
Add prompt text column in dashboard

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -31,6 +31,7 @@ async function refreshList() {
         <td>${i + 1}</td>
         <td><a href="#" onclick="showDetails('${p.prompt_id}')">${p.prompt_id}</a></td>
         <td>${new Date(p.created_at).toLocaleString()}</td>
+        <td><pre>${p.prompt_text}</pre></td>
         <td>${(p.metrics.right_error_description * 100).toFixed(1)}%</td>
         <td>${(p.metrics.correct_hint * 100).toFixed(1)}%</td>
         <td>${(p.metrics.correct_or_absent_code * 100).toFixed(1)}%</td>

--- a/static/index.html
+++ b/static/index.html
@@ -27,6 +27,7 @@
       max-height: 80vh;
       overflow-y: auto;
     }
+    pre { white-space: pre-wrap; margin: 0; }
   </style>
 </head>
 <body>
@@ -53,6 +54,7 @@
           <th>Rank</th>
           <th>Prompt ID</th>
           <th>Created At</th>
+          <th>Prompt</th>
           <th>Right Err</th>
           <th>Hint</th>
           <th>No Code</th>


### PR DESCRIPTION
## Summary
- show submitted prompt text in the main table
- wrap long prompts using a new CSS rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cf292f6883219f2e76e72a71065a