### PR TITLE
Use dedicated evaluation model

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ aggregated evaluation results.
    ```
 3. Open `http://localhost:8000/` in a browser to use the dashboard.
 
-By default both generation and evaluation requests are sent to the same LLM
-endpoint. Set the environment variable `USE_SINGLE_LLM_ENDPOINT=false` to
-restore the previous behaviour with separate endpoints.
+By default generation and validation requests are sent to different LLM models.
+Set the environment variable `USE_SINGLE_LLM_ENDPOINT=true` to send both
+requests to the same endpoint.
 
 To verify the code, run the test suite with:
 ```bash

--- a/pipeline.py
+++ b/pipeline.py
@@ -50,9 +50,9 @@ _ANSWER_URL = (
     "http://zeliboba.yandex-team.ru/balance/32b_aligned_quantized_202502/generative"
 )
 _EVAL_URL_DEFAULT = (
-    "http://zeliboba.yandex-team.ru/balance/qwen3_23B_edu_ml/v1/chat/completions"
+    "http://zeliboba.yandex-team.ru/balance/deepseek_r1_0528/generative"
 )
-_USE_SINGLE_LLM_ENDPOINT = os.getenv("USE_SINGLE_LLM_ENDPOINT", "true").lower() in (
+_USE_SINGLE_LLM_ENDPOINT = os.getenv("USE_SINGLE_LLM_ENDPOINT", "false").lower() in (
     "1",
     "true",
     "yes",
@@ -85,31 +85,18 @@ def call_generation_llm(messages, params=None) -> str:
 
 def call_validation_llm(messages, max_tokens: int = 32000, temperature: int = 0) -> str:
     """Send messages to the validation LLM and return the text response."""
-    if _USE_SINGLE_LLM_ENDPOINT:
-        payload = {
-            "messages": messages,
-            "Params": {"NumHypos": 1, "Seed": 42},
-        }
-        print(f"[LLM Request] url={_EVAL_URL} payload={json.dumps(payload, ensure_ascii=False)}")
-        resp = requests.post(_EVAL_URL, headers=_HEADERS, json=payload)
-        resp.raise_for_status()
-        data = resp.json()
-        chunk = data["Responses"][0]
-        if not chunk.get("ReachedEos"):
-            raise RuntimeError("validation generation did not finish with eos")
-        return chunk["Response"]
-    else:
-        payload = {
-            "model": "does_not_matter",
-            "messages": messages,
-            "stream": False,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-        }
-        print(f"[LLM Request] url={_EVAL_URL} payload={json.dumps(payload, ensure_ascii=False)}")
-        resp = requests.post(_EVAL_URL, headers=_HEADERS, json=payload)
-        resp.raise_for_status()
-        return resp.json()["choices"][0]["message"]["content"]
+    payload = {
+        "messages": messages,
+        "Params": {"NumHypos": 1, "Seed": 42},
+    }
+    print(f"[LLM Request] url={_EVAL_URL} payload={json.dumps(payload, ensure_ascii=False)}")
+    resp = requests.post(_EVAL_URL, headers=_HEADERS, json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+    chunk = data["Responses"][0]
+    if not chunk.get("ReachedEos"):
+        raise RuntimeError("validation generation did not finish with eos")
+    return chunk["Response"]
 
 
 with open("basket.json") as f:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -133,8 +133,8 @@ def test_call_validation_llm_separate_endpoint(monkeypatch):
 
             def json(self):
                 return {
-                    "choices": [
-                        {"message": {"content": "fine"}}
+                    "Responses": [
+                        {"Response": "fine", "ReachedEos": True}
                     ]
                 }
 
@@ -152,11 +152,8 @@ def test_call_validation_llm_separate_endpoint(monkeypatch):
     assert captured['url'] == pipeline._EVAL_URL
     assert captured['headers'] == pipeline._HEADERS
     assert captured['json'] == {
-        "model": "does_not_matter",
         "messages": [{"role": "user", "content": "hi"}],
-        "stream": False,
-        "max_tokens": 10,
-        "temperature": 1,
+        "Params": {"NumHypos": 1, "Seed": 42},
     }
 
 


### PR DESCRIPTION
## Summary
- default the evaluation LLM endpoint to the `deepseek_r1_0528` model
- send validation requests with the generative API
- update environment variable notes in README
- adapt tests to the new validation request format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d1d8809883218172128477eac75d