### PR TITLE
Update evaluation endpoint

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,6 +7,7 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 os.environ.setdefault('ZELIBOBA_TOKEN', 'dummy')
+os.environ.setdefault('ELIZA_API', 'dummy_eval')
 
 def test_process_prompt_triggers_missing_greenlet_error():
     from pipeline import process_prompt
@@ -110,10 +111,10 @@ def test_call_validation_llm_single_endpoint(monkeypatch):
 
     assert result == "ok"
     assert captured['url'] == pipeline._EVAL_URL
-    assert captured['headers'] == pipeline._HEADERS
+    assert captured['headers'] == pipeline._EVAL_HEADERS
     assert captured['json'] == {
+        "model": "deepseek-ai/deepseek-v3",
         "messages": [{"role": "user", "content": "hi"}],
-        "Params": {"NumHypos": 1, "Seed": 42},
     }
 
 
@@ -150,10 +151,10 @@ def test_call_validation_llm_separate_endpoint(monkeypatch):
 
     assert result == "fine"
     assert captured['url'] == pipeline._EVAL_URL
-    assert captured['headers'] == pipeline._HEADERS
+    assert captured['headers'] == pipeline._EVAL_HEADERS
     assert captured['json'] == {
+        "model": "deepseek-ai/deepseek-v3",
         "messages": [{"role": "user", "content": "hi"}],
-        "Params": {"NumHypos": 1, "Seed": 42},
     }
 
 


### PR DESCRIPTION
## Summary
- switch evaluation model to Yandex Together API
- adjust `call_validation_llm` implementation
- update tests for new payload and headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d5a93b0c8321a06104098f2ecd46