### PR TITLE
Update validation parsing

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -96,9 +96,16 @@ def test_call_validation_llm_single_endpoint(monkeypatch):
 
             def json(self):
                 return {
-                    "Responses": [
-                        {"Response": "ok", "ReachedEos": True}
-                    ]
+                    "key": "any",
+                    "response": {
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": "ok"
+                                }
+                            }
+                        ]
+                    }
                 }
 
         return Resp()
@@ -134,9 +141,14 @@ def test_call_validation_llm_separate_endpoint(monkeypatch):
 
             def json(self):
                 return {
-                    "Responses": [
-                        {"Response": "fine", "ReachedEos": True}
-                    ]
+                    "key": "another",
+                    "response": {
+                        "choices": [
+                            {
+                                "message": {"content": "fine"}
+                            }
+                        ]
+                    }
                 }
 
         return Resp()


### PR DESCRIPTION
## Summary
- support new evaluation response format in `call_validation_llm`
- update tests for changed API response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d9d0cbcc8321abe3bb0386d9f2b2