### PR TITLE
Improve LLM request reliability

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -41,7 +41,7 @@ def test_call_generation_llm_parses_response(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr(pipeline.requests, "post", fake_post)
+    monkeypatch.setattr(pipeline._SESSION, "post", fake_post)
 
     params = {"NumHypos": 1, "Seed": 42}
     result = pipeline.call_generation_llm(
@@ -74,7 +74,7 @@ def test_call_generation_llm_raises_on_no_eos(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr(pipeline.requests, "post", fake_post)
+    monkeypatch.setattr(pipeline._SESSION, "post", fake_post)
 
     with pytest.raises(RuntimeError):
         pipeline.call_generation_llm([{"role": "user", "content": "hi"}])
@@ -110,7 +110,7 @@ def test_call_validation_llm_single_endpoint(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr(pipeline.requests, "post", fake_post)
+    monkeypatch.setattr(pipeline._SESSION, "post", fake_post)
     monkeypatch.setattr(pipeline, "_USE_SINGLE_LLM_ENDPOINT", True)
     monkeypatch.setattr(pipeline, "_EVAL_URL", "http://example.com/eval")
 
@@ -153,7 +153,7 @@ def test_call_validation_llm_separate_endpoint(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr(pipeline.requests, "post", fake_post)
+    monkeypatch.setattr(pipeline._SESSION, "post", fake_post)
     monkeypatch.setattr(pipeline, "_USE_SINGLE_LLM_ENDPOINT", False)
     monkeypatch.setattr(pipeline, "_EVAL_URL", "http://other.com/eval")
 
@@ -187,3 +187,45 @@ def test_evaluate_answer_sends_user_message(monkeypatch):
 
     assert captured['messages'][0]['role'] == 'user'
     assert program in captured['messages'][0]['content']
+
+
+def test_process_prompt_handles_connection_error(monkeypatch):
+    import pipeline
+
+    async def fake_get_session():
+        class DummySession:
+            async def exec(self, *args, **kwargs):
+                class Res:
+                    def one(self_inner):
+                        return type('PV', (), {'prompt_id': 'p'})()
+
+                return Res()
+
+            def add(self, *args, **kwargs):
+                pass
+
+            async def commit(self):
+                pass
+
+        yield DummySession()
+
+    class DummyResponseRecord:
+        def __init__(self, **kwargs):
+            pass
+
+    async def dummy_log(*args, **kwargs):
+        pass
+
+    def raise_conn(*args, **kwargs):
+        raise pipeline.requests.exceptions.ConnectionError()
+
+    monkeypatch.setattr(pipeline, 'get_session', fake_get_session)
+    monkeypatch.setattr(pipeline, 'select', lambda *a, **k: type('Sel', (), {'where': lambda self, *a, **k: self})())
+    monkeypatch.setattr(pipeline, 'PromptVersion', type('PV', (), {'prompt_id': 'x'}))
+    monkeypatch.setattr(pipeline, 'ResponseRecord', DummyResponseRecord)
+    monkeypatch.setattr(pipeline, 'log_interaction', dummy_log)
+    monkeypatch.setattr(pipeline._SESSION, 'post', raise_conn)
+    monkeypatch.setattr(pipeline, 'BASKET', [{'id': '1'}])
+
+    # Should not raise despite connection error
+    asyncio.run(pipeline.process_prompt('pid', '{{ value }}'))


### PR DESCRIPTION
## Summary
- add retry logic and session configuration for LLM calls
- handle runtime errors gracefully when processing prompts
- adapt tests for session usage
- ensure process_prompt tolerates connection failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e012ca9c8321bb9fb949c3528b0f